### PR TITLE
Add react-native-date-picker link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A pure JavaScript implementation of the iOS style wheel spinner dropdown picker that is typically used for date and time selection.
 
 - Supports one or many columns (list segments).
-- Show any data in the picklists, not just dates and times.
+- Show any data in the picklists, not just [dates and times](https://github.com/henninghall/react-native-date-picker).
 - Customisable colors and sizing.
 - Does not rely on native dependencies (`npm link` not required).
 - Works with apps built on [Expo](https://expo.io).


### PR DESCRIPTION
Adds a link to the [`react-native-date-picker`](https://github.com/henninghall/react-native-date-picker) library. This would still be the suggested library for showing date and time data (if using native extensions is not an issue).