### PR TITLE
Fix crash when using visbile prop to show/hide

### DIFF
--- a/src/components/SegmentedPicker/SegmentedPicker.tsx
+++ b/src/components/SegmentedPicker/SegmentedPicker.tsx
@@ -12,11 +12,13 @@ import {
 } from 'react-native';
 import * as Animatable from 'react-native-animatable';
 import { defaultProps, propTypes } from './SegmentedPickerPropTypes';
-import styles, { GUTTER_HEIGHT, ITEM_HEIGHT } from './SegmentedPickerStyles';
+import styles from './SegmentedPickerStyles';
 import Cache from '../../services/Cache';
 import { PickerItem, PickerOptions, Selections } from '../../config/interfaces';
 import {
   ANIMATION_TIME,
+  GUTTER_HEIGHT,
+  ITEM_HEIGHT,
   FLAT_LIST_REF,
   LAST_SCROLL_OFFSET,
   SCROLL_DIRECTION,
@@ -102,12 +104,15 @@ export default class SegmentedPicker extends Component<Props, State> {
    */
   hide = async (): Promise<void> => {
     if (Platform.OS === 'ios') {
-      this.setState({ visible: false });
+      this.setState({ visible: false }, () => {
+        this.cache.purge();
+      });
     } else {
       this.modalContainerRef.current.fadeOut(ANIMATION_TIME);
       await this.pickerContainerRef.current.fadeOut(ANIMATION_TIME);
-      this.setState({ visible: false });
-      this.cache.set(IS_DIRTY, false);
+      this.setState({ visible: false }, () => {
+        this.cache.purge();
+      });
     }
   };
 

--- a/src/components/SegmentedPicker/SegmentedPickerStyles.ts
+++ b/src/components/SegmentedPicker/SegmentedPickerStyles.ts
@@ -1,9 +1,10 @@
 import { StyleSheet } from 'react-native';
-
-export const GUTTER_WIDTH = 18;
-export const GUTTER_HEIGHT = 5;
-export const ITEM_HEIGHT = 50;
-export const TEXT_CORRECTION = 2;
+import {
+  GUTTER_WIDTH,
+  GUTTER_HEIGHT,
+  ITEM_HEIGHT,
+  TEXT_CORRECTION,
+} from '../../config/constants';
 
 export default StyleSheet.create({
   modalContainer: {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,11 @@
+/**
+ * Time in milliseconds for the list to fade in and out when displayed.
+ */
+export const ANIMATION_TIME = 300;
+
+/**
+ * Measurement and internal lifecycle tracking states.
+ */
 export const FLAT_LIST_REF = 'FLAT_LIST_REF_';
 export const LAST_SCROLL_OFFSET = 'LAST_SCROLL_OFFSET_';
 export const SCROLL_DIRECTION = 'SCROLL_DIRECTION_';

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,17 @@
+import { Platform } from 'react-native';
+
 /**
  * Time in milliseconds for the list to fade in and out when displayed.
  */
 export const ANIMATION_TIME = 300;
+
+/**
+ * Fixed sizing for list items and other UI elements.
+ */
+export const GUTTER_WIDTH = 18;
+export const GUTTER_HEIGHT = 5;
+export const ITEM_HEIGHT = Platform.select({ ios: 46, default: 50 });
+export const TEXT_CORRECTION = 2;
 
 /**
  * Measurement and internal lifecycle tracking states.

--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -1,5 +1,6 @@
 export interface PickerItem {
   label: string;
+  key?: string;
   [x: string]: any;
 }
 


### PR DESCRIPTION
This patch should fix issue #7.

It fixes a crash which happens when using the `visible` prop to control visibility. The library was trying to fade out the component after it was being hidden due to a logic error in the previous
"isVisible()" function which returned true too early.

I have also implemented some updates to make the closing of the picker smoother on iOS, regardless of whether you're using the `visible` prop or the `ref.hide()` method directly.

This wasn't picked up previously because of the way the `react-native-animatable` is mocked in the unit tests using fake timers. I will also make sure that there's a proper example added to the `examples` project to ensure this is now fully working as expected.