### PR TITLE
Feature/on value change expose selections

### DIFF
--- a/src/components/SegmentedPicker/SegmentedPicker.test.tsx
+++ b/src/components/SegmentedPicker/SegmentedPicker.test.tsx
@@ -161,9 +161,22 @@ describe('SegmentedPicker', () => {
       .toBe(`${COL_1}_${column.items[1].key}`);
   });
 
-  it('Can switch selected items by label name.', () => {
+  it('Can switch selected items by label name.', (done) => {
     const ref: React.RefObject<SegmentedPicker> = React.createRef();
-    const onChangeCallback = jest.fn();
+    const onChangeCallback = (event, selections) => {
+      try {
+        expect(event).toStrictEqual({
+          column: 'col_1',
+          value: 'harry',
+        });
+        expect(selections).toStrictEqual({
+          col_1: expect.any(String),
+        });
+        done();
+      } catch (error) {
+        done(error);
+      }
+    };
     renderer.create(
       <SegmentedPicker
         ref={ref}
@@ -185,21 +198,25 @@ describe('SegmentedPicker', () => {
     );
     jest.advanceTimersByTime(ANIMATION_TIME);
     ref.current.selectLabel('Adam', 'col_1'); // <-- already selected
-    expect(onChangeCallback).not.toBeCalled();
     ref.current.selectLabel('Harry', 'col_1');
-    expect(onChangeCallback).toBeCalledTimes(1);
-    expect(onChangeCallback.mock.calls[0][0]).toStrictEqual({
-      column: 'col_1',
-      value: 'harry',
-    });
-    expect(onChangeCallback.mock.calls[0][1]).toStrictEqual({
-      col_1: 'harry',
-    });
   });
 
-  it('Can switch selected items by value.', () => {
+  it('Can switch selected items by value.', (done) => {
     const ref: React.RefObject<SegmentedPicker> = React.createRef();
-    const onChangeCallback = jest.fn();
+    const onChangeCallback = (event, selections) => {
+      try {
+        expect(event).toStrictEqual({
+          column: 'col_1',
+          value: 'francesca',
+        });
+        expect(selections).toStrictEqual({
+          col_1: expect.any(String),
+        });
+        done();
+      } catch (error) {
+        done(error);
+      }
+    };
     renderer.create(
       <SegmentedPicker
         ref={ref}
@@ -221,21 +238,25 @@ describe('SegmentedPicker', () => {
     );
     jest.advanceTimersByTime(ANIMATION_TIME);
     ref.current.selectValue('adam', 'col_1'); // <-- already selected
-    expect(onChangeCallback).not.toBeCalled();
     ref.current.selectValue('francesca', 'col_1');
-    expect(onChangeCallback).toBeCalledTimes(1);
-    expect(onChangeCallback.mock.calls[0][0]).toStrictEqual({
-      column: 'col_1',
-      value: 'francesca',
-    });
-    expect(onChangeCallback.mock.calls[0][1]).toStrictEqual({
-      col_1: 'francesca',
-    });
   });
 
-  it('Can switch selected items by list index.', () => {
+  it('Can switch selected items by list index.', (done) => {
     const ref: React.RefObject<SegmentedPicker> = React.createRef();
-    const onChangeCallback = jest.fn();
+    const onChangeCallback = (event, selections) => {
+      try {
+        expect(event).toStrictEqual({
+          column: 'col_1',
+          value: 'georgia',
+        });
+        expect(selections).toStrictEqual({
+          col_1: expect.any(String),
+        });
+        done();
+      } catch (error) {
+        done(error);
+      }
+    };
     renderer.create(
       <SegmentedPicker
         ref={ref}
@@ -257,15 +278,6 @@ describe('SegmentedPicker', () => {
     );
     jest.advanceTimersByTime(ANIMATION_TIME);
     ref.current.selectIndex(0, 'col_1'); // <-- already selected
-    expect(onChangeCallback).not.toBeCalled();
     ref.current.selectIndex(3, 'col_1');
-    expect(onChangeCallback).toBeCalledTimes(1);
-    expect(onChangeCallback.mock.calls[0][0]).toStrictEqual({
-      column: 'col_1',
-      value: 'georgia',
-    });
-    expect(onChangeCallback.mock.calls[0][1]).toStrictEqual({
-      col_1: 'georgia',
-    });
   });
 });

--- a/src/components/SegmentedPicker/SegmentedPicker.test.tsx
+++ b/src/components/SegmentedPicker/SegmentedPicker.test.tsx
@@ -192,6 +192,9 @@ describe('SegmentedPicker', () => {
       column: 'col_1',
       value: 'harry',
     });
+    expect(onChangeCallback.mock.calls[0][1]).toStrictEqual({
+      col_1: 'harry',
+    });
   });
 
   it('Can switch selected items by value.', () => {
@@ -225,6 +228,9 @@ describe('SegmentedPicker', () => {
       column: 'col_1',
       value: 'francesca',
     });
+    expect(onChangeCallback.mock.calls[0][1]).toStrictEqual({
+      col_1: 'francesca',
+    });
   });
 
   it('Can switch selected items by list index.', () => {
@@ -257,6 +263,9 @@ describe('SegmentedPicker', () => {
     expect(onChangeCallback.mock.calls[0][0]).toStrictEqual({
       column: 'col_1',
       value: 'georgia',
+    });
+    expect(onChangeCallback.mock.calls[0][1]).toStrictEqual({
+      col_1: 'georgia',
     });
   });
 });

--- a/src/components/SegmentedPicker/SegmentedPicker.tsx
+++ b/src/components/SegmentedPicker/SegmentedPicker.tsx
@@ -62,7 +62,7 @@ export interface Props {
   selectionBorderColor: string;
   backgroundColor: string;
   // Events
-  onValueChange: (event: SelectionEvent) => void;
+  onValueChange: (event: SelectionEvent, selections: Selections) => void;
   onCancel: (event: Selections) => void,
   onConfirm: (event: Selections) => void,
 }
@@ -253,7 +253,7 @@ export default class SegmentedPicker extends Component<Props, State> {
         [column]: items[index].value,
       };
       if (emitEvent) {
-        onValueChange({ column, value: items[index].value });
+        onValueChange({ column, value: items[index].value }, this.selectionChanges);
       }
     }
   };
@@ -616,7 +616,7 @@ export default class SegmentedPicker extends Component<Props, State> {
     { nativeEvent: { column, value } }: UIPickerValueChangeEvent,
   ): void => {
     const { onValueChange } = this.props;
-    onValueChange({ column, value });
+    onValueChange({ column, value }, this.selectionChanges);
   };
 
   render() {

--- a/src/components/SegmentedPicker/SegmentedPicker.tsx
+++ b/src/components/SegmentedPicker/SegmentedPicker.tsx
@@ -224,12 +224,12 @@ export default class SegmentedPicker extends Component<Props, State> {
    * @param {boolean = true} emitEvent: Specify whether to call the `onValueChange` event.
    * @return {void}
    */
-  selectIndex = (
+  selectIndex = async (
     index: number,
     column: string,
     animated: boolean = true,
     emitEvent: boolean = true,
-  ): void => {
+  ): Promise<void> => {
     if (this.isNative()) {
       this.uiPickerManager.selectIndex(index, column, animated);
       return;
@@ -253,7 +253,8 @@ export default class SegmentedPicker extends Component<Props, State> {
         [column]: items[index].value,
       };
       if (emitEvent) {
-        onValueChange({ column, value: items[index].value }, this.selectionChanges);
+        const selections = { ...(await this.getCurrentSelections()) };
+        onValueChange({ column, value: items[index].value }, selections);
       }
     }
   };

--- a/src/components/SegmentedPicker/SegmentedPicker.tsx
+++ b/src/components/SegmentedPicker/SegmentedPicker.tsx
@@ -612,11 +612,12 @@ export default class SegmentedPicker extends Component<Props, State> {
    * @param {UIPickerValueChangeEvent}
    * @return {void}
    */
-  private uiPickerValueChange = (
+  private uiPickerValueChange = async (
     { nativeEvent: { column, value } }: UIPickerValueChangeEvent,
-  ): void => {
+  ): Promise<void> => {
     const { onValueChange } = this.props;
-    onValueChange({ column, value }, this.selectionChanges);
+    const selections = { ...(await this.getCurrentSelections()) };
+    onValueChange({ column, value }, selections);
   };
 
   render() {


### PR DESCRIPTION
## Problem:
`onValueChange` tells us when the user interacts with the picker, and provides the column and value of the event.
However, when we edit the `options` prop after the initial render, we do not know what is shown as selected to the user.

## Solution:
Pass the selections out as a parameter when `onValueChange` is called as an additional argument.

## Notes
Ive left this as a draft at the moment, as the unit test for this is difficult to make consistent due to race conditions (Hence the `expect.any(String)`), and I am yet to test the changes on a real device.